### PR TITLE
Remove user songs

### DIFF
--- a/src/Room/components/Player/index.tsx
+++ b/src/Room/components/Player/index.tsx
@@ -12,7 +12,7 @@ import { State, actions } from './redux'
 
 const PlayerWrapper = system(
   {
-    is: 'div',
+    as: 'div',
     pt: '56.25%'
   },
   {
@@ -23,7 +23,7 @@ const PlayerWrapper = system(
 
 const VideoPlayerIcon = system(
   {
-    is: Card,
+    as: Card,
     alignItems: 'center',
     bg: 'white',
     color: 'offBlack',

--- a/src/Room/components/UserSong/index.tsx
+++ b/src/Room/components/UserSong/index.tsx
@@ -4,6 +4,7 @@ import system from '@rebass/components'
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs'
 import uuid from 'uuid/v4'
 
+import { getSingleton } from 'cable'
 import { actions as queueActions } from 'models/queue'
 import { Song } from 'models/song'
 import { State as RootState } from 'reducers'
@@ -28,6 +29,9 @@ type Props = Actions & PassedProps & State
 class UserSong extends React.Component<Props, {}> {
   componentDidMount() {
     this.props.getUserQueue(types.GET_USER_QUEUE_OK, types.GET_USER_QUEUE_ERR)
+
+    const client = getSingleton()
+    client.subscribeTo('userSong').roomSong(this.props.roomId, this.props.updateUserSongs)
   }
 
   enqueueSongs = (songs: Song[]) => {

--- a/src/Room/components/UserSong/redux/actions.ts
+++ b/src/Room/components/UserSong/redux/actions.ts
@@ -11,7 +11,13 @@ const updateOrder: ActionCreators['UpdateOrder'] = (dragIndex, hoverIndex) => ({
   hoverIndex,
 })
 
+const updateUserSongs: ActionCreators['UpdateUserSongs'] = (queue) => ({
+  type: types.UPDATE_USER_SONGS,
+  queue,
+})
+
 export default {
   enqueueSongs,
   updateOrder,
+  updateUserSongs,
 }

--- a/src/Room/components/UserSong/redux/reducers.ts
+++ b/src/Room/components/UserSong/redux/reducers.ts
@@ -16,6 +16,10 @@ export default function reducer(state: State = initialState, action: Action): St
       songs.splice(action.dragIndex, 1)
       songs.splice(action.hoverIndex, 0, card)
       return { ...state, enqueuedSongs: [...songs] }
+    case types.UPDATE_USER_SONGS:
+      const enqueuedSongIds = action.queue.map(q => q.id)
+      const stillEnqueuedSongs = state.enqueuedSongs.filter(q => enqueuedSongIds.includes(q.id))
+      return { ...state, enqueuedSongs: stillEnqueuedSongs }
     default:
       return state
   }

--- a/src/Room/components/UserSong/redux/types.ts
+++ b/src/Room/components/UserSong/redux/types.ts
@@ -4,12 +4,14 @@ const ENQUEUE_SONGS = 'app/Room/UserSong/ENQUEUE_SONGS'
 const GET_USER_QUEUE_OK = 'app/Room/UserSong/GET_USER_QUEUE_OK'
 const GET_USER_QUEUE_ERR = 'app/Room/UserSong/GET_USER_QUEUE_ERR'
 const UPDATE_ORDER = 'app/Room/UserSong/UPDATE_ORDER'
+const UPDATE_USER_SONGS = 'app/Room/UserSong/UPDATE_USER_SONGS'
 
 type Types = {
   ENQUEUE_SONGS: typeof ENQUEUE_SONGS
   GET_USER_QUEUE_OK: typeof GET_USER_QUEUE_OK
   GET_USER_QUEUE_ERR: typeof GET_USER_QUEUE_ERR
   UPDATE_ORDER: typeof UPDATE_ORDER
+  UPDATE_USER_SONGS: typeof UPDATE_USER_SONGS
 }
 
 export const types: Types = {
@@ -17,6 +19,7 @@ export const types: Types = {
   GET_USER_QUEUE_OK,
   GET_USER_QUEUE_ERR,
   UPDATE_ORDER,
+  UPDATE_USER_SONGS,
 }
 
 type EnqueueSongs = (songs: EnqueuedSong[]) => {
@@ -30,14 +33,21 @@ type UpdateOrder = (dragIndex: number, hoverIndex: number) => {
   hoverIndex: number
 }
 
+type UpdateUserSongs = (queue: Queue[]) => {
+  type: typeof UPDATE_USER_SONGS
+  queue: Queue[]
+}
+
 export type Action =
   | ReturnType<GetUserQueueOK<Types['GET_USER_QUEUE_OK']>>
   | ReturnType<EnqueueSongs>
   | ReturnType<UpdateOrder>
+  | ReturnType<UpdateUserSongs>
 
 export type ActionCreators = {
   EnqueueSongs: EnqueueSongs
   UpdateOrder: UpdateOrder
+  UpdateUserSongs: UpdateUserSongs
 }
 
 type EnqueuedSong = Pick<Queue, 'id' | 'song'>


### PR DESCRIPTION
@DLavin23 @sisk 

Allows the UserSong component to also subscribe to updates to the room's enqueued songs.  When receiving a message, it checks all user songs to make sure they're still enqueued in the room -- and removes any that are no longer (because they've been deleted, or because they've been chosen to be played in the room).

![ordering](https://user-images.githubusercontent.com/664467/56710677-fa599280-66ec-11e9-81f3-4e9ec7fffcc0.gif)
